### PR TITLE
Fix mirror link in popups (issue #2)

### DIFF
--- a/static/ngk.js
+++ b/static/ngk.js
@@ -59,7 +59,7 @@ app.directive('ngkCommentPopup', function ($sce, $compile, $http) {
                 '      <a href="http://govnokod.ru/user/{{post.user_id}}">{{post.user_name}}</a>' +
                 '      насрал в ' +
                 '      <a href="http://govnokod.ru/{{post.post_id}}">#{{post.post_id}}</a>' +
-                '      (<a href="#!/{{post.post_id}}#comment{{comment.id}}">Зеркало на NGK</a>)' +
+                '      (<a href="#!/{{post.id}}">Зеркало на NGK</a>)' +
                 '      ({{post.posted}})' +
                 '    </div>' +
                 '    <pre>{{post.code}}</pre>' +

--- a/static/ngk.js
+++ b/static/ngk.js
@@ -58,7 +58,7 @@ app.directive('ngkCommentPopup', function ($sce, $compile, $http) {
                 '    <div class="info">' +
                 '      <a href="http://govnokod.ru/user/{{post.user_id}}">{{post.user_name}}</a>' +
                 '      насрал в ' +
-                '      <a href="http://govnokod.ru/{{post.post_id}}">#{{post.post_id}}</a>' +
+                '      <a href="http://govnokod.ru/{{post.id}}">#{{post.id}}</a>' +
                 '      (<a href="#!/{{post.id}}">Зеркало на NGK</a>)' +
                 '      ({{post.posted}})' +
                 '    </div>' +


### PR DESCRIPTION
Поправил ссылки на зеркало для попапов с родительским постом. Ссылалось на битую `ngk/#!/#comment`.

P.S. Ссылка на оригинальный пост на ГК у них тоже была битая, поправил.